### PR TITLE
Add XYZ file support

### DIFF
--- a/benchmarks/benchmark_xyz.py
+++ b/benchmarks/benchmark_xyz.py
@@ -6,29 +6,30 @@ import numpy as np
 import pytest
 
 
-def create_xyz_data(i: int):
+@pytest.fixture
+def structures() -> list[flour.XyzData]:
     num_atoms = 100
-    return flour.XyzData(
-        comment="Test comment!",
-        elements=['C']*num_atoms,
-        positions=np.random.default_rng(i).random((num_atoms, 3)) * 100
-    )
-
-
-def create_xyz_structures():
-    return [create_xyz_data(i) for i in range(500)]
+    rng = np.random.default_rng(11)
+    return [
+        flour.XyzData(
+            comment="Test comment",
+            elements=["C"]*num_atoms,
+            positions=rng.random((num_atoms, 3)) * 100,
+        )
+        for _ in range(500)
+    ]
 
 
 @pytest.mark.benchmark(group="write_xyz")
 def benchmark_write_xyz(
     benchmark: typing.Any,
     tmp_path: pathlib.Path,
+    structures: list[flour.XyzData],
 ) -> None:
-    xyz_structures = create_xyz_structures()
     benchmark(
         flour.write_xyz,
         path=tmp_path / "bench.xyz",
-        xyz_structures=xyz_structures
+        xyz_structures=structures
     )
 
 
@@ -36,11 +37,11 @@ def benchmark_write_xyz(
 def benchmark_read_xyz(
     benchmark: typing.Any,
     tmp_path: pathlib.Path,
+    structures: list[flour.XyzData],
 ) -> None:
     path = tmp_path / "bench.xyz"
-    xyz_structures = create_xyz_structures()
     flour.write_xyz(
         path=path,
-        xyz_structures=xyz_structures
+        xyz_structures=structures
     )
     benchmark(flour.read_xyz, path)

--- a/benchmarks/benchmark_xyz.py
+++ b/benchmarks/benchmark_xyz.py
@@ -1,0 +1,46 @@
+import pathlib
+import typing
+
+import flour
+import numpy as np
+import pytest
+
+
+def create_xyz_data(i: int):
+    num_atoms = 100
+    return flour.XyzData(
+        comment="Test comment!",
+        elements=['C']*num_atoms,
+        positions=np.random.default_rng(i).random((num_atoms, 3)) * 100
+    )
+
+
+def create_xyz_structures():
+    return [create_xyz_data(i) for i in range(500)]
+
+
+@pytest.mark.benchmark(group="write_xyz")
+def benchmark_write_xyz(
+    benchmark: typing.Any,
+    tmp_path: pathlib.Path,
+) -> None:
+    xyz_structures = create_xyz_structures()
+    benchmark(
+        flour.write_xyz,
+        path=tmp_path / "bench.xyz",
+        xyz_structures=xyz_structures
+    )
+
+
+@pytest.mark.benchmark(group="read_xyz")
+def benchmark_read_xyz(
+    benchmark: typing.Any,
+    tmp_path: pathlib.Path,
+) -> None:
+    path = tmp_path / "bench.xyz"
+    xyz_structures = create_xyz_structures()
+    flour.write_xyz(
+        path=path,
+        xyz_structures=xyz_structures
+    )
+    benchmark(flour.read_xyz, path)

--- a/flour.pyi
+++ b/flour.pyi
@@ -29,3 +29,15 @@ def write_cube(
     voxels: npt.NDArray[np.float64],
 ) -> None:
     pass
+
+
+class XyzData:
+    elements: list[str]
+    comment: str
+    positions: npt.NDArray[np.float64]
+
+def read_xyz(path: pathlib.Path | str) -> list[XyzData]:
+    pass
+
+def write_xyz(path: pathlib.Path | str, xyz_structures: list[XyzData]) -> None:
+    pass

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,10 +192,16 @@ fn write_cube(
     Ok(())
 }
 
+#[pyfunction]
+fn write_xyz(path: PathBuf, comment: &str) -> PyResult<()> {
+    Ok(())
+}
+
 /// A Python module implemented in Rust.
 #[pymodule]
 fn flour(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(read_cube, m)?)?;
     m.add_function(wrap_pyfunction!(write_cube, m)?)?;
+    m.add_function(wrap_pyfunction!(write_xyz, m)?)?;
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,6 +197,8 @@ struct XyzData {
     #[pyo3(get)]
     elements: String,
     #[pyo3(get)]
+    comment: String,
+    #[pyo3(get)]
     positions: Py<PyArray2<f64>>,
 }
 
@@ -214,9 +216,14 @@ fn read_xyz(py: Python, path: PathBuf) -> PyResult<XyzData> {
         .ok_or_else(|| PyRuntimeError::new_err("xyz file does not define the number of atoms"))?
         .parse::<usize>()?;
 
+    let second_line = lines
+        .next()
+        .ok_or_else(|| PyRuntimeError::new_err("xyz file is missing lines"))?;
+
     let mut positions: Vec<f64> = vec![1.0; 9];
     Ok(XyzData {
         elements: num_atoms.to_string(),
+        comment: second_line.to_string(),
         positions: positions.into_pyarray(py).reshape([3, 3])?.to_owned(),
     })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,6 +205,14 @@ fn write_xyz(
     content.push('\n');
     content.push_str(comment);
     content.push('\n');
+
+    izip!(elements, positions.axis_iter(Axis(0))).for_each(|(element, position)| {
+        content.push_str(&format!(
+            "{} {: >11.6} {: >11.6} {: >11.6} \n",
+            element, position[0], position[1], position[2],
+        ))
+    });
+
     fs::write(path, content)?;
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,6 +192,23 @@ fn write_cube(
     Ok(())
 }
 
+#[pyclass]
+struct XyzData {
+    #[pyo3(get)]
+    elements: Py<Vec<String>>,
+    #[pyo3(get)]
+    positions: Py<PyArray2<f64>>,
+}
+
+/// Read a `.xyz` file.
+#[pyfunction]
+fn read_xyz(py: Python, path: PathBuf) -> PyResult<XyzData> {
+    Ok(XyzData {
+        elements: Py<Vec<String>> = Vec::with_capacity(5),
+        positions: PyArray2::new(py, [4, 3], false),
+    })
+}
+
 #[pyfunction]
 fn write_xyz(
     path: PathBuf,
@@ -223,5 +240,6 @@ fn flour(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(read_cube, m)?)?;
     m.add_function(wrap_pyfunction!(write_cube, m)?)?;
     m.add_function(wrap_pyfunction!(write_xyz, m)?)?;
+    m.add_function(wrap_pyfunction!(read_xyz, m)?)?;
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,15 +220,10 @@ fn read_xyz(py: Python, path: PathBuf) -> PyResult<Vec<XyzData>> {
     let mut multi_xyz_data: Vec<XyzData> = vec![];
     let contents = fs::read_to_string(path)?;
     let mut lines = contents.lines();
-    loop {
-        let Some(first_line) = lines.next() else {break};
+    while let (Some(first_line), Some(second_line)) = (lines.next(), lines.next()) {
         let mut first_line_words = first_line.split_ascii_whitespace();
         let Some(num_atoms) = first_line_words.next() else {break};
         let num_atoms = num_atoms.parse::<usize>()?;
-
-        let second_line = lines
-            .next()
-            .ok_or_else(|| PyRuntimeError::new_err("xyz file is missing lines"))?;
 
         let mut elements = Vec::with_capacity(num_atoms);
         let mut positions = Vec::with_capacity(num_atoms * 3);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,7 +193,19 @@ fn write_cube(
 }
 
 #[pyfunction]
-fn write_xyz(path: PathBuf, comment: &str, elements: Vec<String>) -> PyResult<()> {
+fn write_xyz(
+    path: PathBuf,
+    comment: &str,
+    elements: Vec<String>,
+    positions: PyReadonlyArray2<f64>,
+) -> PyResult<()> {
+    let positions = positions.as_array();
+
+    let mut content: String = elements.len().to_string();
+    content.push('\n');
+    content.push_str(comment);
+    content.push('\n');
+    fs::write(path, content)?;
     Ok(())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,6 +202,18 @@ struct XyzData {
     positions: Py<PyArray2<f64>>,
 }
 
+#[pymethods]
+impl XyzData {
+    #[new]
+    fn new(comment: String, elements: Vec<String>, positions: Py<PyArray2<f64>>) -> Self {
+        XyzData {
+            elements,
+            comment,
+            positions,
+        }
+    }
+}
+
 /// Read a `.xyz` file.
 #[pyfunction]
 fn read_xyz(py: Python, path: PathBuf) -> PyResult<Vec<XyzData>> {
@@ -276,5 +288,6 @@ fn flour(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(write_cube, m)?)?;
     m.add_function(wrap_pyfunction!(write_xyz, m)?)?;
     m.add_function(wrap_pyfunction!(read_xyz, m)?)?;
+    m.add_class::<XyzData>()?;
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,7 +193,7 @@ fn write_cube(
 }
 
 #[pyfunction]
-fn write_xyz(path: PathBuf, comment: &str) -> PyResult<()> {
+fn write_xyz(path: PathBuf, comment: &str, elements: Vec<String>) -> PyResult<()> {
     Ok(())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,9 +274,8 @@ fn write_xyz(path: PathBuf, xyz_structures: Vec<PyRef<XyzData>>) -> PyResult<()>
                 element, position[0], position[1], position[2],
             ))
         });
-
-        fs::write(&path, &content)?;
     }
+    fs::write(path, content)?;
     Ok(())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,7 +195,7 @@ fn write_cube(
 #[pyclass]
 struct XyzData {
     #[pyo3(get)]
-    elements: Py<Vec<String>>,
+    elements: String,
     #[pyo3(get)]
     positions: Py<PyArray2<f64>>,
 }
@@ -203,9 +203,10 @@ struct XyzData {
 /// Read a `.xyz` file.
 #[pyfunction]
 fn read_xyz(py: Python, path: PathBuf) -> PyResult<XyzData> {
+    let mut positions: Vec<f64> = vec![1.0; 9];
     Ok(XyzData {
-        elements: Py<Vec<String>> = Vec::with_capacity(5),
-        positions: PyArray2::new(py, [4, 3], false),
+        elements: String::from("Hello"),
+        positions: positions.into_pyarray(py).reshape([3, 3])?.to_owned(),
     })
 }
 

--- a/tests/test_xyz.py
+++ b/tests/test_xyz.py
@@ -32,10 +32,8 @@ def test_xyz(
         assert xyz_file.readline() == f'{comment}\n'
         assert xyz_file.readline() == 'Pd    1.000000    2.000000    3.000000 \n'
     xyz_data = flour.read_xyz(xyz_path)
-    assert xyz_data.elements == '4'
-    assert xyz_data.comment == comment
-    assert np.all(np.isclose(xyz_data.positions, np.array([1.0] * 9).reshape((3,3))))
-    return
+    assert xyz_data.elements == '4' # TODO: get this actually working
     assert comment == xyz_data.comment
-    assert np.all(np.isclose(elements, xyz_data.elements))
     assert np.all(np.isclose(positions, xyz_data.positions))
+    return
+    assert np.all(np.isclose(elements, xyz_data.elements))

--- a/tests/test_xyz.py
+++ b/tests/test_xyz.py
@@ -43,4 +43,3 @@ def test_xyz(
     assert xyz_data_1.comment == xyz_structures[1].comment
     assert np.all(np.equal(xyz_data_1.elements, xyz_structures[1].elements))
     assert np.all(np.isclose(xyz_data_1.positions, xyz_structures[1].positions))
-    

--- a/tests/test_xyz.py
+++ b/tests/test_xyz.py
@@ -9,7 +9,8 @@ def test_xyz(
 ) -> None:
 
     xyz_path = tmp_path / "molecule.xyz"
-    atoms = np.array([1, 10, 20, 30], dtype=np.uint8)
+    comment = "comment"
+    elements = np.array(['Pd', 'C', 'O', 'H'])
     positions = np.array(
         [
             [1.0, 2.0, 3.0],
@@ -20,12 +21,13 @@ def test_xyz(
     )
     flour.write_xyz(
         path=xyz_path,
-        title1="title1",
-        title2="title2",
-        atoms=atoms,
-        positions=positions,
+        comment=comment,
+        # atoms=elements,
+        # positions=positions,
     )
-
+    assert True
+    return
     xyz_data = flour.read_xyz(xyz_path)
-    assert np.all(np.isclose(atoms, xyz_data.atoms))
+    assert comment == xyz_data.comment
+    assert np.all(np.isclose(elements, xyz_data.elements))
     assert np.all(np.isclose(positions, xyz_data.positions))

--- a/tests/test_xyz.py
+++ b/tests/test_xyz.py
@@ -23,9 +23,13 @@ def test_xyz(
         path=xyz_path,
         comment=comment,
         elements=elements,
-        # positions=positions,
+        positions=positions,
     )
     assert True
+    assert xyz_path.exists()
+    with open(xyz_path) as xyz_file:
+        assert xyz_file.readline() == '4\n'
+        assert xyz_file.readline() == f'{comment}\n'
     return
     xyz_data = flour.read_xyz(xyz_path)
     assert comment == xyz_data.comment

--- a/tests/test_xyz.py
+++ b/tests/test_xyz.py
@@ -32,7 +32,7 @@ def test_xyz(
         assert xyz_file.readline() == f'{comment}\n'
         assert xyz_file.readline() == 'Pd    1.000000    2.000000    3.000000 \n'
     xyz_data = flour.read_xyz(xyz_path)
-    assert xyz_data.elements == 'Hello'
+    assert xyz_data.elements == '4'
     assert np.all(np.isclose(xyz_data.positions, np.array([1.0] * 9).reshape((3,3))))
     return
     assert comment == xyz_data.comment

--- a/tests/test_xyz.py
+++ b/tests/test_xyz.py
@@ -1,0 +1,31 @@
+import pathlib
+
+import flour
+import numpy as np
+
+
+def test_xyz(
+    tmp_path: pathlib.Path,
+) -> None:
+
+    xyz_path = tmp_path / "molecule.xyz"
+    atoms = np.array([1, 10, 20, 30], dtype=np.uint8)
+    positions = np.array(
+        [
+            [1.0, 2.0, 3.0],
+            [4.0, 5.0, 6.0],
+            [7.0, 8.0, 9.0],
+            [10.0, 11.0, 12.0],
+        ]
+    )
+    flour.write_xyz(
+        path=xyz_path,
+        title1="title1",
+        title2="title2",
+        atoms=atoms,
+        positions=positions,
+    )
+
+    xyz_data = flour.read_xyz(xyz_path)
+    assert np.all(np.isclose(atoms, xyz_data.atoms))
+    assert np.all(np.isclose(positions, xyz_data.positions))

--- a/tests/test_xyz.py
+++ b/tests/test_xyz.py
@@ -19,30 +19,28 @@ def test_xyz(
             [10.0, 11.0, 12.0],
         ]
     )
-    flour.write_xyz(
-        path=xyz_path,
-        comment=comment,
-        elements=elements,
-        positions=positions,
-    )
-    
-    xyz_data = flour.read_xyz(xyz_path)
-    assert comment == xyz_data[0].comment
-    assert np.all(np.equal(elements, xyz_data[0].elements))
-    assert np.all(np.isclose(positions, xyz_data[0].positions))
-    
-    # test reading an XYZ file with multiple structures
-    multi_xyz_path = pathlib.Path('C:/Users/Joshua/OneDrive/Desktop/iqmol_scratch/conformers_4_dft.xyz')
-    multi_xyz_data = flour.read_xyz(multi_xyz_path)
-    assert (len(multi_xyz_data)) == 28
-    assert multi_xyz_data[0].comment == '-33286.03927246263'
-    for i, current_xyz_data in enumerate(multi_xyz_data):
-        assert len(current_xyz_data.elements) == 61
-    assert multi_xyz_data[27].elements[60] == 'H'
-    assert np.isclose(multi_xyz_data[27].positions[60,2], -3.171669)
-    
-    xyz_constructor_data = flour.XyzData(
+    xyz_data_0 = flour.XyzData(
         comment=comment,
         elements=elements,
         positions=positions
     )
+    xyz_data_1 = flour.XyzData(
+        comment=comment+'!',
+        elements=elements[::-1],
+        positions=positions*-1
+    )
+    
+    flour.write_xyz(
+        path=xyz_path,
+        xyz_structures=[xyz_data_0, xyz_data_1],
+    )
+    
+    xyz_structures = flour.read_xyz(xyz_path)
+    assert comment == xyz_structures[0].comment
+    assert np.all(np.equal(elements, xyz_structures[0].elements))
+    assert np.all(np.isclose(positions, xyz_structures[0].positions))
+    
+    assert xyz_data_1.comment == xyz_structures[1].comment
+    assert np.all(np.equal(xyz_data_1.elements, xyz_structures[1].elements))
+    assert np.all(np.isclose(xyz_data_1.positions, xyz_structures[1].positions))
+    

--- a/tests/test_xyz.py
+++ b/tests/test_xyz.py
@@ -25,15 +25,9 @@ def test_xyz(
         elements=elements,
         positions=positions,
     )
-    assert True
-    assert xyz_path.exists()
-    with open(xyz_path) as xyz_file:
-        assert xyz_file.readline() == '4\n'
-        assert xyz_file.readline() == f'{comment}\n'
-        assert xyz_file.readline() == 'Pd    1.000000    2.000000    3.000000 \n'
+    
     xyz_data = flour.read_xyz(xyz_path)
-    assert xyz_data.elements == '4' # TODO: get this actually working
     assert comment == xyz_data.comment
+    assert np.all(np.equal(elements, xyz_data.elements))
     assert np.all(np.isclose(positions, xyz_data.positions))
     return
-    assert np.all(np.isclose(elements, xyz_data.elements))

--- a/tests/test_xyz.py
+++ b/tests/test_xyz.py
@@ -27,7 +27,16 @@ def test_xyz(
     )
     
     xyz_data = flour.read_xyz(xyz_path)
-    assert comment == xyz_data.comment
-    assert np.all(np.equal(elements, xyz_data.elements))
-    assert np.all(np.isclose(positions, xyz_data.positions))
-    return
+    assert comment == xyz_data[0].comment
+    assert np.all(np.equal(elements, xyz_data[0].elements))
+    assert np.all(np.isclose(positions, xyz_data[0].positions))
+    
+    # test reading an XYZ file with multiple structures
+    multi_xyz_path = pathlib.Path('C:/Users/Joshua/OneDrive/Desktop/iqmol_scratch/conformers_4_dft.xyz')
+    multi_xyz_data = flour.read_xyz(multi_xyz_path)
+    assert (len(multi_xyz_data)) == 28
+    assert multi_xyz_data[0].comment == '-33286.03927246263'
+    for i, current_xyz_data in enumerate(multi_xyz_data):
+        assert len(current_xyz_data.elements) == 61
+    assert multi_xyz_data[27].elements[60] == 'H'
+    assert np.isclose(multi_xyz_data[27].positions[60,2], -3.171669)

--- a/tests/test_xyz.py
+++ b/tests/test_xyz.py
@@ -30,6 +30,7 @@ def test_xyz(
     with open(xyz_path) as xyz_file:
         assert xyz_file.readline() == '4\n'
         assert xyz_file.readline() == f'{comment}\n'
+        assert xyz_file.readline() == 'Pd    1.000000    2.000000    3.000000 \n'
     return
     xyz_data = flour.read_xyz(xyz_path)
     assert comment == xyz_data.comment

--- a/tests/test_xyz.py
+++ b/tests/test_xyz.py
@@ -31,8 +31,8 @@ def test_xyz(
         assert xyz_file.readline() == '4\n'
         assert xyz_file.readline() == f'{comment}\n'
         assert xyz_file.readline() == 'Pd    1.000000    2.000000    3.000000 \n'
-    return
     xyz_data = flour.read_xyz(xyz_path)
+    return
     assert comment == xyz_data.comment
     assert np.all(np.isclose(elements, xyz_data.elements))
     assert np.all(np.isclose(positions, xyz_data.positions))

--- a/tests/test_xyz.py
+++ b/tests/test_xyz.py
@@ -10,7 +10,7 @@ def test_xyz(
 
     xyz_path = tmp_path / "molecule.xyz"
     comment = "comment"
-    elements = np.array(['Pd', 'C', 'O', 'H'])
+    elements = ['Pd', 'C', 'O', 'H']
     positions = np.array(
         [
             [1.0, 2.0, 3.0],
@@ -22,7 +22,7 @@ def test_xyz(
     flour.write_xyz(
         path=xyz_path,
         comment=comment,
-        # atoms=elements,
+        elements=elements,
         # positions=positions,
     )
     assert True

--- a/tests/test_xyz.py
+++ b/tests/test_xyz.py
@@ -40,3 +40,9 @@ def test_xyz(
         assert len(current_xyz_data.elements) == 61
     assert multi_xyz_data[27].elements[60] == 'H'
     assert np.isclose(multi_xyz_data[27].positions[60,2], -3.171669)
+    
+    xyz_constructor_data = flour.XyzData(
+        comment=comment,
+        elements=elements,
+        positions=positions
+    )

--- a/tests/test_xyz.py
+++ b/tests/test_xyz.py
@@ -9,7 +9,7 @@ def test_xyz(
 ) -> None:
 
     xyz_path = tmp_path / "molecule.xyz"
-    comment = "comment"
+    comment = "Test comment!"
     elements = ['Pd', 'C', 'O', 'H']
     positions = np.array(
         [
@@ -33,6 +33,7 @@ def test_xyz(
         assert xyz_file.readline() == 'Pd    1.000000    2.000000    3.000000 \n'
     xyz_data = flour.read_xyz(xyz_path)
     assert xyz_data.elements == '4'
+    assert xyz_data.comment == comment
     assert np.all(np.isclose(xyz_data.positions, np.array([1.0] * 9).reshape((3,3))))
     return
     assert comment == xyz_data.comment

--- a/tests/test_xyz.py
+++ b/tests/test_xyz.py
@@ -32,6 +32,8 @@ def test_xyz(
         assert xyz_file.readline() == f'{comment}\n'
         assert xyz_file.readline() == 'Pd    1.000000    2.000000    3.000000 \n'
     xyz_data = flour.read_xyz(xyz_path)
+    assert xyz_data.elements == 'Hello'
+    assert np.all(np.isclose(xyz_data.positions, np.array([1.0] * 9).reshape((3,3))))
     return
     assert comment == xyz_data.comment
     assert np.all(np.isclose(elements, xyz_data.elements))


### PR DESCRIPTION
Here are notes and questions that have come up so far. Most notably, going from 1 to 2 supported file formats means that a number of decisions came up regarding how the code and functionality associated with different file formats would be related.

1. In adding a second file format, should there be some sort of shared data structure that stores molecular data consistently across different types of files? Is there already a cheminformatic standard available in rust analogous to rdkit, open babel, or stk? Does ruSTK have a molecule data structure yet?
2. Should all the rust code continue to live in lib.rs with the XYZ file related rust functions in the same module / file as the Cube file related functions, or should they be distributed into separate modules and or files?
3. I'm only starting to learn how borrowing and lifetimes work in rust. I clumsily messed with the XYZData class and usage of it until compilation succeeded. I don't know if I'm using types owned by python vs rust appropriately, and whether I should actually need to have the Python GIL when writing the file.
4. I'm getting a warning to update maturin
5. I wasn't easily able to get github actions to run on my fork and it seemed like they might be referring to secrets on this main repo. Compilation and pytest succeed locally. I still need to run the other code checks from the justfile because I was running into a couple issues trying to setup just.

Remaining todo list:
- [ ] Edit based on Lukas's feedback
- [ ] Update README
- [ ] Run code checks and fixes

closes https://github.com/joshkamm/FLOUR/issues/1